### PR TITLE
Us381

### DIFF
--- a/src/components/TableEntry.jsx
+++ b/src/components/TableEntry.jsx
@@ -153,7 +153,7 @@ const EntryItem = ({ entrySnapshot, dbKey, entryUIState, setEntryData, entryData
 
     let size = 1;
     if (entrySnapshot.data()[dbKey] !== undefined) {
-        size = entrySnapshot.data()[dbKey].length;
+        size = String(entrySnapshot.data()[dbKey]).length;
     }
 
     return (

--- a/src/const/tableLabels.js
+++ b/src/const/tableLabels.js
@@ -1,3 +1,5 @@
+import { getArthropodLabels } from "../utils/firestore";
+
 const keyLabelMap = {
     dateTime: 'Date & Time',
     recorder: 'Recorder',
@@ -128,6 +130,18 @@ const snakeLabels = [
     'Comments',
 ];
 
+const dynamicArthropodLabels = async () => {
+    return [
+        'Date & Time',
+        'Site',
+        'Array',
+        'Fence Trap',
+        'Predator?',
+        ...await getArthropodLabels(),
+        'Comments'
+    ]
+}
+
 const arthropodLabels = [
     'Date & Time',
     'Site',
@@ -197,3 +211,16 @@ export const TABLE_LABELS = {
     Arthropod: arthropodLabels,
     Amphibian: amphibianLabels,
 };
+
+export const loadLabels = async () => {
+    const dynamicArthropod = await dynamicArthropodLabels()
+    return {
+        Session: sessionLabels,
+        Turtle: turtleLabels,
+        Lizard: lizardLabels,
+        Mammal: mammalLabels,
+        Snake: snakeLabels,
+        Arthropod: dynamicArthropod,
+        Amphibian: amphibianLabels,
+    }
+}

--- a/src/const/tableLabels.js
+++ b/src/const/tableLabels.js
@@ -130,7 +130,7 @@ const snakeLabels = [
     'Comments',
 ];
 
-const dynamicArthropodLabels = async () => {
+export const dynamicArthropodLabels = async () => {
     return [
         'Date & Time',
         'Site',
@@ -211,16 +211,3 @@ export const TABLE_LABELS = {
     Arthropod: arthropodLabels,
     Amphibian: amphibianLabels,
 };
-
-export const loadLabels = async () => {
-    const dynamicArthropod = await dynamicArthropodLabels()
-    return {
-        Session: sessionLabels,
-        Turtle: turtleLabels,
-        Lizard: lizardLabels,
-        Mammal: mammalLabels,
-        Snake: snakeLabels,
-        Arthropod: dynamicArthropod,
-        Amphibian: amphibianLabels,
-    }
-}

--- a/src/modals/FormBuilderModal.jsx
+++ b/src/modals/FormBuilderModal.jsx
@@ -1,7 +1,7 @@
 import Modal from "../components/Modal";
 import { FormBuilder } from "../pages";
 
-export default function FormBuilderModal({ showModal, onCancel, onOkay }) {
+export default function FormBuilderModal({ showModal, onCancel, onOkay, setLabelsLoaded }) {
     return (
         <Modal
             showModal={showModal}
@@ -11,7 +11,7 @@ export default function FormBuilderModal({ showModal, onCancel, onOkay }) {
             text='Build custom forms with Field Day!'
         >
             <div className="w-full-modal-width">
-                <FormBuilder />
+                <FormBuilder setLabelsLoaded={setLabelsLoaded} />
             </div>
             
         </Modal>

--- a/src/modals/FormBuilderModal.jsx
+++ b/src/modals/FormBuilderModal.jsx
@@ -1,7 +1,7 @@
 import Modal from "../components/Modal";
 import { FormBuilder } from "../pages";
 
-export default function FormBuilderModal({ showModal, onCancel, onOkay, setLabelsLoaded }) {
+export default function FormBuilderModal({ showModal, onCancel, onOkay, triggerRerender }) {
     return (
         <Modal
             showModal={showModal}
@@ -11,7 +11,7 @@ export default function FormBuilderModal({ showModal, onCancel, onOkay, setLabel
             text='Build custom forms with Field Day!'
         >
             <div className="w-full-modal-width">
-                <FormBuilder setLabelsLoaded={setLabelsLoaded} />
+                <FormBuilder triggerRerender={triggerRerender} />
             </div>
             
         </Modal>

--- a/src/pages/TablePage.jsx
+++ b/src/pages/TablePage.jsx
@@ -20,7 +20,7 @@ export default function TablePage() {
     const [entries, setEntries] = useState([]);
     const [labels, setLabels] = useState();
     const [activeTool, setActiveTool] = useState('none');
-    const [labelsLoaded, setLabelsLoaded] = useState(false);
+    const [rerender, setRerender] = useState(false);
 
     const [currentProject, setCurrentProject] = useAtom(currentProjectName);
     const [tableName, setTableName] = useAtom(currentTableName);
@@ -34,15 +34,16 @@ export default function TablePage() {
         setLabels(await dynamicArthropodLabels())
     }
 
+    const triggerRerender = () => setRerender(!rerender);
+
     useEffect(() => {
         if (tableName === 'Arthropod') {
             loadDynamicArthropodLabels();
         } else {
             setLabels(TABLE_LABELS[tableName])
         }
-        setLabelsLoaded(true);
         loadBatch()
-    }, [tableName, batchSize, currentProject, labelsLoaded]);
+    }, [tableName, batchSize, currentProject, rerender]);
 
     const tabsData = [
         { text: 'Turtle', icon: <TurtleIcon /> },
@@ -60,7 +61,7 @@ export default function TablePage() {
                 showModal={activeTool === 'formBuilder'}
                 onCancel={() => setActiveTool('none')}
                 onOkay={() => setActiveTool('none')}
-                setLabelsLoaded={setLabelsLoaded}
+                triggerRerender={triggerRerender}
             />
             <ExportModal
                 showModal={activeTool === 'export'}

--- a/src/pages/TablePage.jsx
+++ b/src/pages/TablePage.jsx
@@ -22,6 +22,7 @@ export default function TablePage() {
     const [entries, setEntries] = useState([]);
     const [labels, setLabels] = useState();
     const [activeTool, setActiveTool] = useState('none');
+    const [labelsLoaded, setLabelsLoaded] = useState(false);
 
     const [currentProject, setCurrentProject] = useAtom(currentProjectName);
     const [tableName, setTableName] = useAtom(currentTableName);
@@ -29,21 +30,24 @@ export default function TablePage() {
 
     const { loadBatch, loadNextBatch, loadPreviousBatch } = usePagination(setEntries);
 
+    entries[0] && console.log(entries[0].data());
 
-    const doInitialSetup = async () => {
+    const loadTableLabels = async () => {
         const labels = await loadLabels()
         console.log(labels);
         setLabels(labels[tableName]);
-        hasInitialSetupBeenCalled.current = true;
+        setLabelsLoaded(true);
     }
 
     useEffect(() => {
-        doInitialSetup()
-    }, [])
+        if (!labelsLoaded) {
+            loadTableLabels()
+        }
+    }, [labelsLoaded])
 
     useEffect(() => {
         loadBatch()
-    }, [tableName, batchSize, currentProject]);
+    }, [tableName, batchSize, currentProject, labelsLoaded]);
 
     const tabsData = [
         { text: 'Turtle', icon: <TurtleIcon /> },
@@ -60,7 +64,8 @@ export default function TablePage() {
             <FormBuilderModal
                 showModal={activeTool === 'formBuilder'}
                 onCancel={() => setActiveTool('none')}
-                onOkay={() => console.log('okay then...')}
+                onOkay={() => setActiveTool('none')}
+                setLabelsLoaded={setLabelsLoaded}
             />
             <ExportModal
                 showModal={activeTool === 'export'}

--- a/src/pages/TablePage.jsx
+++ b/src/pages/TablePage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import PageWrapper from './PageWrapper';
 import { Pagination } from '../components/Pagination';
 import TabBar from '../components/TabBar';
-import { TABLE_LABELS } from '../const/tableLabels';
+import { TABLE_LABELS, dynamicArthropodLabels } from '../const/tableLabels';
 import DataManager from '../tools/DataManager';
 import { useAtom } from 'jotai';
 import { currentBatchSize, currentProjectName, currentTableName } from '../utils/jotai';
@@ -13,10 +13,8 @@ import FormBuilderModal from '../modals/FormBuilderModal';
 import ExportModal from '../modals/ExportModal';
 import NewSessionModal from '../modals/NewSessionModal';
 import NewDataModal from '../modals/NewDataModal';
-import { loadLabels } from '../const/tableLabels';
 import { usePagination } from '../hooks/usePagination';
 import Button from '../components/Button';
-import { useRef } from 'react';
 
 export default function TablePage() {
     const [entries, setEntries] = useState([]);
@@ -30,22 +28,19 @@ export default function TablePage() {
 
     const { loadBatch, loadNextBatch, loadPreviousBatch } = usePagination(setEntries);
 
-    entries[0] && console.log(entries[0].data());
+    // entries[0] && console.log(entries[0].data());
 
-    const loadTableLabels = async () => {
-        const labels = await loadLabels()
-        console.log(labels);
-        setLabels(labels[tableName]);
-        setLabelsLoaded(true);
+    const loadDynamicArthropodLabels = async () => {
+        setLabels(await dynamicArthropodLabels())
     }
 
     useEffect(() => {
-        if (!labelsLoaded) {
-            loadTableLabels()
+        if (tableName === 'Arthropod') {
+            loadDynamicArthropodLabels();
+        } else {
+            setLabels(TABLE_LABELS[tableName])
         }
-    }, [labelsLoaded])
-
-    useEffect(() => {
+        setLabelsLoaded(true);
         loadBatch()
     }, [tableName, batchSize, currentProject, labelsLoaded]);
 

--- a/src/pages/TablePage.jsx
+++ b/src/pages/TablePage.jsx
@@ -13,9 +13,10 @@ import FormBuilderModal from '../modals/FormBuilderModal';
 import ExportModal from '../modals/ExportModal';
 import NewSessionModal from '../modals/NewSessionModal';
 import NewDataModal from '../modals/NewDataModal';
-
+import { loadLabels } from '../const/tableLabels';
 import { usePagination } from '../hooks/usePagination';
 import Button from '../components/Button';
+import { useRef } from 'react';
 
 export default function TablePage() {
     const [entries, setEntries] = useState([]);
@@ -28,9 +29,20 @@ export default function TablePage() {
 
     const { loadBatch, loadNextBatch, loadPreviousBatch } = usePagination(setEntries);
 
+
+    const doInitialSetup = async () => {
+        const labels = await loadLabels()
+        console.log(labels);
+        setLabels(labels[tableName]);
+        hasInitialSetupBeenCalled.current = true;
+    }
+
     useEffect(() => {
-        setLabels(TABLE_LABELS[tableName]);
-        loadBatch();
+        doInitialSetup()
+    }, [])
+
+    useEffect(() => {
+        loadBatch()
     }, [tableName, batchSize, currentProject]);
 
     const tabsData = [

--- a/src/tools/FormBuilder.jsx
+++ b/src/tools/FormBuilder.jsx
@@ -156,10 +156,6 @@ export default function FormBuilder({ triggerRerender }) {
                     let newDocumentDataToUpdate = structuredClone(documentToUpdate.data());
                     delete newDocumentDataToUpdate[activeDocumentDataPrimary.toLowerCase()]
                     newDocumentDataToUpdate[formData.primary.toLowerCase()] = speciesData;
-                    console.log('old data:')
-                    console.log(documentToUpdate.data())
-                    console.log('new data:')
-                    console.log(newDocumentDataToUpdate)
                     batch.set(
                         doc(
                             db, 

--- a/src/tools/FormBuilder.jsx
+++ b/src/tools/FormBuilder.jsx
@@ -5,7 +5,7 @@ import { db } from '../utils/firebase';
 import { notify, Type } from '../components/Notifier';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 
-export default function FormBuilder({ setLabelsLoaded }) {
+export default function FormBuilder({ triggerRerender }) {
     const [activeCollection, setActiveCollection] = useState(''); // current collection selected
     const [documents, setDocuments] = useState([]); // array of all documents with just their data
     const [documentSnapshots, setDocumentSnapshots] = useState([]); // array of all documents, as Firestore document objects
@@ -171,8 +171,8 @@ export default function FormBuilder({ setLabelsLoaded }) {
             }
             await batch.commit();
         }
-        notify(Type.success, 'Successfully changed data!')
-        setLabelsLoaded(false);
+        notify(Type.success, 'Successfully changed corresponding entries!')
+        triggerRerender()
         setEditAllEntriesModal(false);
     }
 

--- a/src/tools/FormBuilder.jsx
+++ b/src/tools/FormBuilder.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { collection, getDocs, setDoc, doc, getDoc, addDoc, where } from 'firebase/firestore';
 import { db } from '../utils/firebase';
 import { notify, Type } from '../components/Notifier';
-import { LayoutGroup, motion } from 'framer-motion';
+import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 
 export default function FormBuilder() {
     const [activeCollection, setActiveCollection] = useState(''); // current collection selected
@@ -15,6 +15,8 @@ export default function FormBuilder() {
     const [activeDocumentDataPrimary, setActiveDocumentDataPrimary] = useState(); // currently selected primary key
     const [formData, setFormData] = useState(); // form data
     const [changeBoxTitle, setChangeBoxTitle] = useState('Edit Data');
+    const [editAllEntriesModal, setEditAllEntriesModal] = useState(true);
+
 
     useEffect(() => {
         const getAllDocs = async () => {
@@ -70,6 +72,10 @@ export default function FormBuilder() {
             });
     };
 
+    const andUpdateAllDocuments = async () => {
+
+    }
+
     const addDocToFirestore = async () => {
         if (activeCollection === 'AnswerSet') {
             const d = new Date();
@@ -101,10 +107,13 @@ export default function FormBuilder() {
         setActiveDocumentDataPrimary(formData.primary);
     };
 
-    const submitChanges = () => {
+    const submitChanges = (
+        options
+    ) => {
         if (changeBoxTitle === 'Edit Data') {
             updateUI();
             pushChangesToFirestore();
+            options === 'andUpdateAllDocuments' && andUpdateAllDocuments();
         } else if (changeBoxTitle === 'Add New Data') {
             activeDocument.answers.push(formData);
             documents[activeDocumentIndex] = activeDocument;
@@ -174,12 +183,61 @@ export default function FormBuilder() {
                 <button
                     onClick={(e) => {
                         e.preventDefault();
-                        submitChanges();
+                        setEditAllEntriesModal(true)
                     }}
                     className="border-gray-800 border-2 m-2 rounded text-xl py-1 px-4 w-min cursor-pointer hover:bg-blue-400 active:bg-blue-500"
                 >
                     Submit
                 </button>
+                <AnimatePresence>{
+                    editAllEntriesModal && 
+                    <motion.div
+                        initial={{
+                            opacity: 0,
+                            y: '10%'
+                        }}
+                        animate={{
+                            opacity: 1,
+                            y: 0,
+                            transition: {
+                                duration: .25
+                            }
+                        }}
+                        exit={{
+                            opacity: 0,
+                            y: '-10%',
+                            transition: {
+                                duration: .25
+                            }
+                        }}
+                        className='absolute inset-0 m-40 flex flex-col items-center justify-around p-4 bg-white border-2 border-black rounded-sm'
+                    >
+                        <p className='text-4xl'>Where would you like to update this data?</p>
+                        <button
+                            className='text-xl p-4 hover:scale-105 transition hover:brightness-110'
+                            onClick={(e) => {
+                                e.preventDefault();
+                                submitChanges()
+                            }}
+                        >Change just this collection</button>
+                        <button
+                            className='text-xl p-4 hover:scale-105 transition hover:brightness-110'
+                            onClick={(e) => {
+                                e.preventDefault();
+                                submitChanges('andUpdateAllDocuments')
+                            }}
+                        >Change this collection and everywhere this data is used (expensive operation)</button>
+                        <button
+                            className='text-xl p-4 hover:scale-105 transition hover:brightness-110'
+                            onClick={(e) => {
+                                e.preventDefault();
+                                setEditAllEntriesModal(false)
+                            }}    
+                        >
+                            Cancel
+                        </button>
+                    </motion.div>
+                }</AnimatePresence>
             </form>
         );
     };
@@ -215,7 +273,7 @@ export default function FormBuilder() {
                 <div className="border-gray-800 border-2 rounded">
                     <h2 className="text-2xl">Collection</h2>
                     <ReusableUnorderedList
-                        listItemArray={['AnswerSet', 'DynamicForms']}
+                        listItemArray={['AnswerSet']}
                         clickHandler={(listItem) => {
                             if (listItem === activeCollection) setActiveCollection('');
                             else setActiveCollection(listItem);

--- a/src/utils/firestore.js
+++ b/src/utils/firestore.js
@@ -14,6 +14,19 @@ import {
 import { db } from './firebase';
 import { Type } from '../components/Notifier';
 
+export const getArthropodLabels = async () => {
+    let labelArray = [];
+    await getDocs(query(
+        collection(db, 'AnswerSet'),
+        where('set_name', '==', 'ArthropodSpecies')
+    )).then(snapshot => {
+        snapshot.docs[0].data().answers.forEach(ans => {
+            labelArray.push(ans.primary)
+        })
+    })
+    return labelArray;
+}
+
 const getDocsFromCollection = async (collectionName, constraints = []) => {
     if (!Array.isArray(constraints)) {
         constraints = [constraints];


### PR DESCRIPTION
Implement user story 381 
(As a user I want to be able to change an answer set entry in answer sets and everywhere in the database where it is used.)

Now the user can change species data and have the choice to recursively update every entry in the database where that species data is used/defined.

Keep in mind this operation is quite expensive, and so far only operates on the **Test** dataset. This means that this will need to be switched over to use the live dataset prior to merge into dev. _Additionally, there is no test AnswerSet collection, so those changes will be made to the "live dataset"_ 

In order to incorporate this feature, I had to change several other files as well:

- `TablePage`, `firestore`, `tableLabels` to incorporate dynamic re-fetching of arthropod labels. Previously, arthropod labels were kept in a static array, but now that the user can dynamically change the keys that the app uses to fetch arthropod data, those need to be generated dynamically as well. All other species besides arthropod are still statically referenced. 
- Also changed `TableEntry` so that the `size` attribute of inputs are based on the length of the _string_, not the length of the _number_ (initially created this to rectify a mistake I made during development (changed a string to a number), but is a good check to make regardless so I'm keeping it in there)