### PR TITLE
feat: improve input handling and error notification

### DIFF
--- a/src/components/TableEntry.jsx
+++ b/src/components/TableEntry.jsx
@@ -101,7 +101,7 @@ export const TableEntry = forwardRef((props, ref) => {
 const EntryItem = ({ entrySnapshot, dbKey, entryUIState, setEntryData, entryData }) => {
     const [editable, setEditable] = useState(true);
 
-    const handleChange = (e) => {
+    const onChangeHandler = (e) => {
         const value = e.target.value.slice(-1);
         const isBinaryKey = BINARY_KEYS.includes(dbKey);
         const isTrueKey = TRUE_KEYS.includes(value);
@@ -113,16 +113,24 @@ const EntryItem = ({ entrySnapshot, dbKey, entryUIState, setEntryData, entryData
         }));
     };
 
-    const disabled = entryUIState === 'viewing' || (entryUIState === 'editing' && !editable) || entryUIState === 'deleting';
+    const onClickHandler = (e) => {
+        if (dbKey === 'year' && entryUIState === 'editing') {
+            notify(Type.error, "Editing the year directly is not supported. Please edit the date instead.");
+        }
+    };
+    
+    let disabled = dbKey === 'year' || entryUIState === 'viewing' || (entryUIState === 'editing' && !editable) || entryUIState === 'deleting';
+
     const size = entryData[dbKey] ? String(entryData[dbKey]).length : 1;
 
     return (
         <td className="text-center border-b border-neutral-400 dark:border-neutral-600 p-1">
             <input
-                disabled={disabled}
-                className="text-center"
+                readOnly={disabled}
+                className="text-center w-full read-only:bg-transparent read-only:border-transparent read-only:focus:outline-none"
                 value={entryData[dbKey] ?? 'N/A'}
-                onChange={handleChange}
+                onChange={(e) => onChangeHandler(e)}
+                onClick={(e) => onClickHandler(e)}
                 size={size}
             />
         </td>

--- a/src/utils/firestore.js
+++ b/src/utils/firestore.js
@@ -111,12 +111,19 @@ const pushEntryChangesToFirestore = async (entrySnapshot, entryData, editMsg) =>
         updateLizardMetadata('update', { lastEditTime });
     }
     let response = [];
-    try {
-        await setDoc(doc(db, entrySnapshot.ref.parent.id, entrySnapshot.id), entryData);
-        response = [Type.success, editMsg || 'Changes successfully written to database!'];
-    } catch (e) {
-        response = [Type.error, `Error writing changes to database: ${e}`];
+    if (entryData.dateTime) {
+        const newDate = new Date(entryData.dateTime);
+        if (!isNaN(newDate)) {
+            entryData.year = newDate.getFullYear();
+        }
     }
+    await setDoc(doc(db, entrySnapshot.ref.parent.id, entrySnapshot.id), entryData)
+        .then(() => {
+            response = [Type.success, editMsg || 'Changes successfully written to database!'];
+        })
+        .catch((e) => {
+            response = [Type.error, `Error writing changes to database: ${e}`];
+        });
     return response;
 };
 


### PR DESCRIPTION
This commit enhances the `EntryItem` component and `pushEntryChangesToFirestore` function to improve user experience and code maintainability.

Changes include:
- Renamed `handleChange` to `onChangeHandler` in `TableEntry.jsx` for better naming consistency.
- Added `onClickHandler` to handle click events, specifically preventing direct editing of the 'year' field.
- Modified input element to use `readOnly` instead of `disabled` when conditions are met, improving the UI's visual feedback.
- Updated firestore utility to set 'year' from 'dateTime' field if present and valid, ensuring data integrity.

Modified files:
- `src/components/TableEntry.jsx`:
  - `handleChange` renamed to `onChangeHandler`.
  - Added `onClickHandler` to notify users when attempting to edit the 'year' directly.
  - Changed `disabled` property to `readOnly` for better UX.
- `src/utils/firestore.js`:
  - Added logic to extract and set 'year' from 'dateTime' field before saving to Firestore.
  - Refactored Firestore operations to use promise chaining for better readability.