### PR TITLE
Add Prettier script for formatting and checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "framer-motion": "^8.5.0",
         "jotai": "^1.13.1",
         "lodash": "^4.17.21",
+        "prettier": "^3.4.2",
         "react": "^18.2.0",
         "react-csv": "^2.2.2",
         "react-dom": "^18.2.0",
@@ -3275,6 +3276,21 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6679,6 +6695,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ=="
     },
     "prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier --write **/*.{html,css,js,md} --config .prettierrc",
+    "format-check": "prettier --check **/*.{html,css,js,md} --config .prettierrc"
   },
   "dependencies": {
     "@blaumaus/react-alert": "^7.0.5",
@@ -18,6 +20,7 @@
     "framer-motion": "^8.5.0",
     "jotai": "^1.13.1",
     "lodash": "^4.17.21",
+    "prettier": "^3.4.2",
     "react": "^18.2.0",
     "react-csv": "^2.2.2",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
- Introduced new npm scripts for code formatting and format checking using Prettier
- `format`: Automatically formats code files with `.html`, `.css`, `.js`, `.md` extensions.
- `format-check`: Checks code files for Prettier formatting compliance.
- Added Prettier as a dependency for consistent code style.

Release-Note: Add npm scripts for code formatting and checking with Prettier