### PR TITLE
Reorder keyLabelMap entries for alphabetical consistency

### DIFF
--- a/src/const/tableLabels.js
+++ b/src/const/tableLabels.js
@@ -42,13 +42,13 @@ const keyLabelMap = {
     hymb: 'HYMB',
     lepi: 'LEPI',
     mant: 'MANT',
+    micro: 'MICRO',
     orth: 'ORTH',
     pseu: 'PSEU',
     scor: 'SCOR',
     soli: 'SOLI',
     thys: 'THYS',
     unki: 'UNKI',
-    micro: 'MICRO',
 };
 
 const sessionLabels = [


### PR DESCRIPTION
Rearrange the entries in the `keyLabelMap` object to maintain alphabetical order within the file `tableLabels.js`, improving readability and consistency.

Release-Note: Reorder keyLabelMap to keep entries alphabetical