### PR TITLE
Add 2024 Capstone Team to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ In order to use Google Auth and access the test deployment, you will need to add
 <a href="https://github.com/realdgrassl"><img src="https://github.com/realdgrassl.png" width="50" height="50" alt="Dennis Grassl"></a>  
 <a href="https://github.com/ianskelskey"><img src="https://github.com/ianskelskey.png" width="50" height="50" alt="Ian Skelskey"></a>
 <a href="https://github.com/zacharyjacobson"><img src="https://github.com/zacharyjacobson.png" width="50" height="50" alt="Zachary Jacobson"></a>
+
+### 2024 Capstone Team
+
+<a href="https://github.com/evanhagood"><img src="https://github.com/evanhagood.png" width="50" height="50" alt="Evan Hagood"></a>
+<a href="https://github.com/ayeshaArif6"><img src="https://github.com/ayeshaArif6.png" width="50" height="50" alt="Ayesha Arif"></a>
+<a href="https://github.com/cmolstad"><img src="https://github.com/cmolstad.png" width="50" height="50" alt="Chase Molstad"></a>
+<a href="https://github.com/tlweave2"><img src="https://github.com/tlweave2.png" width="50" height="50" alt="Timothy Weaver"></a>
+<a href="https://github.com/qknowles"><img src="https://github.com/qknowles.png" width="50" height="50" alt="Quinten Knowles"></a>


### PR DESCRIPTION
This commit updates the README.md file to include the 2024 Capstone Team members. It adds images and links to the GitHub profiles of Evan Hagood, Ayesha Arif, Chase Molstad, Timothy Weaver, and Quinten Knowles.